### PR TITLE
fix no implicit any error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -91,7 +91,7 @@ export interface StorageSyncOptions {
   keys?: string[];
   ignoreActions?: string[];
   hydratedStateKey?: string;
-  onSyncError?: (err) => void
+  onSyncError?: (err: any) => void;
 };
 
 const defaultOptions: StorageSyncOptions = {


### PR DESCRIPTION
When using this package in a project you are required to set `"noImplicitAny": false` in your tsconfig.json.  This PR makes that not necessary.