### PR TITLE
Provide better error logging when failing to hydrate the store

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -83,7 +83,7 @@ export class StorageSyncEffects {
             payload: s
         })
       })
-      .catch(e => console.log(e))
+      .catch(e => console.log(`error fetching data from store for hydration: ${e}`))
   }) 
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,7 +83,7 @@ export class StorageSyncEffects {
             payload: s
         })
       })
-      .catch(e => console.log(`error fetching data from store for hydration`))
+      .catch(e => console.log(e))
   }) 
 }
 


### PR DESCRIPTION
@fiznool  @dfmartin please merge if you have time. The default hardcoded error message is not specific enough. I ran into issues when i had a syntax error but got hardcoded error instead real one in console output.