### PR TITLE
Deep merge initial state and hydrated state

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -44,6 +44,28 @@ function setNested(obj: any, path: string, value: any): any {
   return obj;
 }
 
+// deepmerge
+function isObject(item) {
+  return (item && typeof item === 'object' && !Array.isArray(item));
+}
+
+function mergeDeep(target, source) {
+  let output = Object.assign({}, target);
+  if (isObject(target) && isObject(source)) {
+    Object.keys(source).forEach(key => {
+      if (isObject(source[key])) {
+        if (!(key in target))
+          Object.assign(output, { [key]: source[key] });
+        else
+          output[key] = mergeDeep(target[key], source[key]);
+      } else {
+        Object.assign(output, { [key]: source[key] });
+      }
+    });
+  }
+  return output;
+}
+
 function fetchState(): Promise<{}> {
   return storage
     .get(STORAGE_KEY)
@@ -114,7 +136,7 @@ export function storageSync(options?: StorageSyncOptions) {
       const { type, payload } = action;
 
       if (type === StorageSyncActions.HYDRATED) {
-        state = payload;
+        state = mergeDeep(state, payload);
         if (hydratedStateKey) {
           hydratedState[hydratedStateKey] = true;
         }


### PR DESCRIPTION
⚠️  Need to be fully tested

Just an `Object.assign()` doesn't work as expected because it not deep merge properties.

Fix #7